### PR TITLE
Fixed domains list bug in Sites table

### DIFF
--- a/includes/class-domainer-backend.php
+++ b/includes/class-domainer-backend.php
@@ -161,7 +161,7 @@ final class Backend extends Handler {
 		if ( $domains ) {
 			foreach ( $domains as $domain ) {
 				$domain = new Domain( $domain );
-				printf( '<a href="%1$s%2$s" target="_blank">%3$s</a> (%4$s) <br />', is_ssl() ? 'https://' : 'http://', $domain->fullname(), $domain->type );
+				printf( '<a href="%1$s%2$s" target="_blank">%2$s</a> (%3$s) <br />', is_ssl() ? 'https://' : 'http://', $domain->fullname(), $domain->type );
 			}
 		}
 	}


### PR DESCRIPTION
The bug throws an invalid number of arguments warning and won't list the domains